### PR TITLE
fix table rendering for the team

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Previous projects foci:
 
 ## Team
 
+|||
 | ------- | ------- |
 | [Muhammad S. Abdo](https://www.linkedin.com/in/muhsabrys/) | Luis Abrego |
 | Nada Aggadi | Jose P. Benavides |
@@ -79,6 +80,7 @@ Previous projects foci:
 
 ## Former Team Members
 
+|||
 | ------- | ------- |
 |  Aarnav | Dr. Ali Abdulaziz Aljubailan |
 | Abhishek Babuji | [Oren Baldinger](https://github.com/orenbaldinger) |


### PR DESCRIPTION
@dcavar This PR fixes the tables for the Teams rendered in the README.

Previously tables were rendered like this
![image](https://github.com/user-attachments/assets/9042bd14-3b75-4e1f-b4a4-f89331b21f23)

Now, they're rendered correctly
![image](https://github.com/user-attachments/assets/735577ca-fbb0-4e5e-94ae-0f6ce81bf714)
